### PR TITLE
fix(link): respect -y/--no-interactive flag

### DIFF
--- a/cfgcaddy/__main__.py
+++ b/cfgcaddy/__main__.py
@@ -145,7 +145,7 @@ def link(config, no_interactive):
         mode = "copy" if linker_config.use_copy_mode else "symlink"
         logger.info(f"Running on Termux using {mode} mode")
 
-    caddy = cfgcaddy.linker.Linker(linker_config, interactive=no_interactive)
+    caddy = cfgcaddy.linker.Linker(linker_config, interactive=not no_interactive)
     caddy.create_links()
     caddy.create_custom_links()
 


### PR DESCRIPTION
## Summary
The `link` command passed the `--no-interactive` (`-y`) flag value straight through as `interactive=`, inverting the logic — so `-y` *enabled* the "Are these the correct files?" confirmation prompt instead of suppressing it. In a non-tty context (e.g. an Ansible/bootstrap run with stdin redirected) the prompt then aborted with `Input is not a terminal` / `Aborted!`.

## Changes
- `cfgcaddy/__main__.py`: pass `interactive=not no_interactive` so `-y` runs non-interactively.
- Bump version `0.1.8` → `0.1.9` so `uv tool install` picks up the new build instead of reusing the cached wheel for the same version.

## Testing
- `cfgcaddy link -y </dev/null` now links without prompting and exits 0.
- Verified end-to-end via an Ansible `dotfiles` role run: `PLAY RECAP ... failed=0`, link task `ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)